### PR TITLE
Correção de bug em desenfileira()

### DIFF
--- a/fila.c
+++ b/fila.c
@@ -34,8 +34,11 @@ int desenfileira(fila *fila) {
 		int item = fila->cabeca->item;
 		no *no = fila->cabeca;
 		fila->cabeca = fila->cabeca->proximo;
-		free(no);
 		fila->tamanho--;
+		if(tamanho(fila) == 0) {
+			fila->cauda = NULL;
+		}
+		free(no);
 		return item;
 	}
 }


### PR DESCRIPTION
Bug em desenfileirar() não apontava fila->cauda para NULL em caso específico.